### PR TITLE
Deliver workaround for issue I5: acsetup fails without an error message

### DIFF
--- a/lib/whisk.js
+++ b/lib/whisk.js
@@ -23,7 +23,8 @@ const createAction = function(name, path) {
   var packageCreate = spawn( 'wsk', packageParams);
 
   // create OpenWhisk action
-  var createParams = ['action', 'update', 'autocomplete/'+name, '--kind', 'nodejs:6', path, '--web', 'true'];
+  // I5: apply workaround for server-side issue
+  var createParams = ['action', 'update', 'autocomplete/'+name, '--kind', 'nodejs:6', path, '-a', 'web-export', 'true'];
   var actionCreate = spawn( 'wsk', createParams);
 
   // if there were errors

--- a/lib/whisk.js
+++ b/lib/whisk.js
@@ -22,22 +22,23 @@ const createAction = function(name, path) {
   var packageParams = ['package', 'update', 'autocomplete'];
   var packageCreate = spawn( 'wsk', packageParams);
 
+  if(packageCreate.status) {
+    // package could not be created/updated; display error and abort processing
+    console.error(packageCreate.stderr.toString('utf8').red);
+    return false;
+  }
+
   // create OpenWhisk action
   // I5: apply workaround for server-side issue
   var createParams = ['action', 'update', 'autocomplete/'+name, '--kind', 'nodejs:6', path, '-a', 'web-export', 'true'];
   var actionCreate = spawn( 'wsk', createParams);
 
-  // if there were errors
-  if (actionCreate.status || packageCreate.status) {
-    if (packageCreate.stderr) {
-      console.error(packageCreate.stderr.toString('utf8').red);
-      return false;
-    }
-    if (actionCreate.stderr) {
-      console.error(actionCreate.stderr.toString('utf8').red);
-      return false;
-    }
+  if(actionCreate.status) {
+    // action could not be created/updated; display error and abort processing
+    console.error(actionCreate.stderr.toString('utf8').red);
+    return false;
   }
+
   return true;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-autocomplete",
   "description": "Utility to convert a text file of strings into a autocomplete API powered by serverless OpenWhisk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "autocomplete.js",
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha"


### PR DESCRIPTION
The issue was caused by an OpenWhisk bug.  This PR delivers the recommended workaround for #5. 